### PR TITLE
Removed reference to array

### DIFF
--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -22,13 +22,6 @@ module ActiveRecord
           end
         end
 
-        def type_for_column(column)
-          if column.array
-            @conn.lookup_cast_type("#{column.sql_type}[]")
-          else
-            super
-          end
-        end
       end
 
       module SchemaStatements


### PR DESCRIPTION
There was an extra reference to array which did not allow migrations to run
